### PR TITLE
Refactor make your own poster button

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -131,5 +131,5 @@ showRandomPoster();
 
 function unhideForm() {
   posterForm.classList.toggle("hidden");
-  //mainPage.classList.toggle("hidden")
+  mainPoster.classList.toggle("hidden")
 }


### PR DESCRIPTION
Change: Refactor make your own poster button to hide the main poster area.
Fixed: the main poster area in our last merge was still showing, we refactored the code to hide the main poster.
This is not a new feature and it does not break any existing functionality or contributors will need to pull this current version.
Tested: With classmates, on the browser, and with browser dev tools