### PR TITLE
Saved posters grid

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -162,7 +162,18 @@ function saveThisPoster() {
   }
 }
 
-
+function viewSavedPosterGrid () {
+  savedPosterGrid.innerHTML = ``
+  for (i = 0; i < savedPosters.length; i++) {
+    savedPosterGrid.innerHTML += `
+    <article class ="mini-poster">
+    <img class ="poster-image" src="${savedPosters[i].imageURL}" alt="nothin' to see here">
+    <h2 class ="poster-title">${savedPosters[i].title}</h2>
+    <h4 class ="poster-quote">${savedPosters[i].quote}</h4>
+    </article>
+    `
+  }
+}
 
 function showRandomPoster() {
   posterImages.src = images[getRandomIndex(images)];

--- a/src/main.js
+++ b/src/main.js
@@ -2,28 +2,29 @@
 // Main page
 var posterTitles = document.querySelector('.poster-title');
 var posterQuotes = document.querySelector('.poster-quote');
-var posterImages = document.querySelector(".poster-img");
-var showRandom = document.querySelector(".show-random");
-var showFormButton = document.querySelector(".show-form");
+var posterImages = document.querySelector('.poster-img');
+var showRandom = document.querySelector('.show-random');
+var showFormButton = document.querySelector('.show-form');
 
 //Poster form
-var posterForm = document.querySelector(".poster-form");
-var mainPoster = document.querySelector(".main-poster");
+var posterForm = document.querySelector('.poster-form');
+var mainPoster = document.querySelector('.main-poster');
 
 //Show saved posters
-var savedPostersButton = document.querySelector(".show-saved");
-var savedPostersArea = document.querySelector(".saved-posters");
-var showMainButton = document.querySelector(".show-main");
-var backToMainButton = document.querySelector(".back-to-main");
+var savedPostersButton = document.querySelector('.show-saved');
+var savedPostersArea = document.querySelector('.saved-posters');
+var showMainButton = document.querySelector('.show-main');
+var backToMainButton = document.querySelector('.back-to-main');
 
 //Make your own poster
-var imageURLBox = document.querySelector("#poster-image-url");
-var titleBox = document.querySelector("#poster-title");
-var quoteBox = document.querySelector("#poster-quote");
+var imageURLBox = document.querySelector('#poster-image-url');
+var titleBox = document.querySelector('#poster-title');
+var quoteBox = document.querySelector('#poster-quote');
 var showMyPosterButton = document.querySelector(".make-poster");
 
 //Saved posters
 var saveThisPosterButton = document.querySelector('.save-poster');
+var savedPosterGrid = document.querySelector('.saved-posters-grid');
 
 // we've provided you with some data to work with 👇
 var images = [
@@ -158,6 +159,8 @@ function saveThisPoster() {
   }
 }
 
+
+
 function showRandomPoster() {
   posterImages.src = images[getRandomIndex(images)];
   posterTitles.innerText = titles[getRandomIndex(titles)];
@@ -170,6 +173,7 @@ function unhideForm() {
   posterForm.classList.toggle("hidden");
   mainPoster.classList.toggle("hidden");
 }
+
 
 function unhideSavedPosters() {
   savedPostersArea.classList.toggle("hidden");

--- a/src/main.js
+++ b/src/main.js
@@ -133,7 +133,10 @@ var currentPoster;
 // event listeners go here 👇
 showRandom.addEventListener('click', showRandomPoster);
 showFormButton.addEventListener('click', unhideForm);
-savedPostersButton.addEventListener('click', unhideSavedPosters);
+savedPostersButton.addEventListener('click', function(){
+  viewSavedPosterGrid();
+  unhideSavedPosters()
+});
 showMainButton.addEventListener('click', unhideForm);
 backToMainButton.addEventListener('click', unhideSavedPosters);
 showMyPosterButton.addEventListener('click', showMyPoster);


### PR DESCRIPTION
PR TEMPLATE:
Change: Updated the Show Saved Posters button to show user created posters without duplicating on the page.
Fixed: The Show Saved Posters button will use the saved posters array to create mini posters of the user created posters in the Show Saved Posters view.
This is a new feature and it does not break any existing functionality or force to update to a new version.
Tested: With classmates, on the browser, and with browser dev tools