### PR TITLE
Refactor save poster button to save randomized poster

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -179,6 +179,7 @@ function showRandomPoster() {
   posterImages.src = images[getRandomIndex(images)];
   posterTitles.innerText = titles[getRandomIndex(titles)];
   posterQuotes.innerText = quotes[getRandomIndex(quotes)];
+  storeCurrentPoster();
 }
 
 showRandomPoster();


### PR DESCRIPTION
Change: Refactored Save This Poster button to allow randomized posters to be saved
Fixed: We can now click on the Save This Poster, and then Show Saved Poster button and it will show custom and random posters.
This is not a new feature and it does not break any existing functionality or force to update to a new version.
Tested: With classmates, on the browser, and with browser dev tools